### PR TITLE
tsuru: implement new bind and unbind routes

### DIFF
--- a/dbaas/tsuru/urls.py
+++ b/dbaas/tsuru/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls.defaults import *
 from django.conf import settings
-from views import ListPlans, GetServiceStatus, GetServiceInfo, ServiceAdd, ServiceBind, ServiceRemove
+from views import (ListPlans, GetServiceStatus, GetServiceInfo, ServiceAdd,
+                   ServiceAppBind, ServiceUnitBind, ServiceRemove)
 
 urlpatterns = patterns('tsuru.views',
     url(r'^resources/plans$', ListPlans.as_view()),
@@ -8,5 +9,6 @@ urlpatterns = patterns('tsuru.views',
     url(r'^services/(?P<database_name>\w+)$', GetServiceInfo.as_view()),
     url(r'^resources$', ServiceAdd.as_view()),
     url(r'^resources/(?P<database_name>\w+)$', ServiceRemove.as_view()),
-    url(r'^resources/(?P<database_name>\w+)/bind$', ServiceBind.as_view()),
+    url(r'^resources/(?P<database_name>\w+)/bind$', ServiceUnitBind.as_view()),
+    url(r'^resources/(?P<database_name>\w+)/bind-app$', ServiceAppBind.as_view()),
 )

--- a/dbaas/tsuru/views.py
+++ b/dbaas/tsuru/views.py
@@ -82,7 +82,7 @@ class GetServiceInfo(APIView):
         return Response(info)
 
 
-class ServiceBind(APIView):
+class ServiceAppBind(APIView):
     renderer_classes = (JSONRenderer, JSONPRenderer)
     model = Database
 
@@ -115,9 +115,6 @@ class ServiceBind(APIView):
             msg = "Database {} in env {} does not have credentials.".format(database_name, env)
             return log_and_response(msg=msg, e=e, http_status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        if 'unit-host' in data:
-            bind_address_on_database.delay(database, data['unit-host'], '32', action="permit", user=request.user)
-
         endpoint = database.endpoint.replace('<user>:<password>',"{}:{}".format(
             credential.user, credential.password))
 
@@ -136,7 +133,6 @@ class ServiceBind(APIView):
     def delete(self, request, database_name, format=None):
         env = get_url_env(request)
         data = request.DATA
-        unbind_ip = data.get('unit-host')
         LOG.debug("Request DATA {}".format(data))
 
         task = TaskHistory.objects.filter(Q(arguments__contains=database_name) &
@@ -159,6 +155,61 @@ class ServiceBind(APIView):
             return log_and_response(msg=msg, http_status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
+        return Response(status.HTTP_204_NO_CONTENT)
+
+
+class ServiceUnitBind(APIView):
+    renderer_classes = (JSONRenderer, JSONPRenderer)
+    model = Database
+
+    def post(self, request, database_name, format=None):
+        env = get_url_env(request)
+        data = request.DATA
+        LOG.debug("Request DATA {}".format(data))
+
+        task = TaskHistory.objects.filter(Q(arguments__contains=database_name) &
+            Q(arguments__contains=env), task_status="RUNNING",).order_by("created_at")
+
+        LOG.info("Task {}".format(task))
+        if task:
+            msg = "Database {} in env {} is beeing created.".format(database_name, env)
+            return log_and_response(msg=msg, http_status=status.HTTP_412_PRECONDITION_FAILED)
+
+        try:
+            database = Database.objects.get(name=database_name, environment__name=env)
+        except ObjectDoesNotExist, e:
+            msg = "Database {} does not exist in env {}.".format(database_name, env)
+            return log_and_response(msg=msg, e=e, http_status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        unit_host = data.get('unit-host')
+        bind_address_on_database.delay(database, data['unit-host'], '32', action="permit", user=request.user)
+
+        return Response(None, status.HTTP_201_CREATED)
+
+    def delete(self, request, database_name, format=None):
+        env = get_url_env(request)
+        data = request.DATA
+        LOG.debug("Request DATA {}".format(data))
+
+        task = TaskHistory.objects.filter(Q(arguments__contains=database_name) &
+            Q(arguments__contains=env), task_status="RUNNING",).order_by("created_at")
+
+        LOG.info("Task {}".format(task))
+        if task:
+            msg = "Database {} in env {} is beeing created.".format(database_name, env)
+            return log_and_response(msg=msg, http_status=status.HTTP_412_PRECONDITION_FAILED)
+
+        try:
+            database = Database.objects.filter(name=database_name, environment__name=env).exclude(is_in_quarantine=True)[0]
+        except IndexError, e:
+            msg = "Database {} does not exist in env {}.".format(database_name, env)
+            return log_and_response(msg=msg, e=e, http_status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        if not(database and database.status):
+            msg = "Database {} is not Alive.".format(database_name)
+            return log_and_response(msg=msg, http_status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        unbind_ip = data.get('unit-host')
         bind_address_on_database.delay(database, unbind_ip, '32', action="deny", user=request.user)
         return Response(status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
tsuru 0.9.1 split the binding process in two steps: binding the
application and binding the units. In the application binding, the
service returns the set of environment variables that the application
should use to connect to the database; and in the unit binding the
service will just whitelist the application host(s).

In the case of database-as-a-service, bind unit will `permit` access,
and unbind unit will `deny` access.
