### PR TITLE
Transfer emergency contacts field from database to team

### DIFF
--- a/dbaas/account/migrations/0006_auto__add_field_team_contacts.py
+++ b/dbaas/account/migrations/0006_auto__add_field_team_contacts.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Team.contacts'
+        db.add_column(u'account_team', 'contacts',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Team.contacts'
+        db.delete_column(u'account_team', 'contacts')
+
+
+    models = {
+        u'account.team': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'Team'},
+            'contacts': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'database_alocation_limit': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '2'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Group']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'symmetrical': 'False'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['account']

--- a/dbaas/account/models.py
+++ b/dbaas/account/models.py
@@ -49,6 +49,12 @@ class Team(BaseModel):
     database_alocation_limit = models.PositiveSmallIntegerField(_('DB Alocation Limit'),
                                                                 default=2,
                                                                 help_text="This limits the number of databases that a team can create. 0 for unlimited resources.")
+    contacts = models.TextField(
+        verbose_name=_("Emergency Contacts"), null=True, blank=True,
+        help_text=_(
+            "People to be reached in case of a critical incident. Eg.: 99999999 - Jhon Doe."
+        )
+    )
     role = models.ForeignKey(Role)
     users = models.ManyToManyField(User)
     objects = models.Manager()  # The default manager.
@@ -72,6 +78,10 @@ class Team(BaseModel):
 
     def natural_key(self):
         return (self.name,)
+
+    def clean(self):
+        if not self.contacts:
+            raise ValidationError({'contacts': ('This field is required',)})
 
     @classmethod
     def get_all_permissions_for(cls, user=None):
@@ -127,6 +137,12 @@ class Team(BaseModel):
             LOG.warning(
                 "could not count databases in use for team %s, reason: %s" % (self, e))
             return 0
+
+    @property
+    def emergency_contacts(self):
+        if self.contacts:
+            return self.contacts
+        return 'Not defined. Please, contact the team'
 
 
 def sync_ldap_groups_with_user(user=None):

--- a/dbaas/account/tests/factory.py
+++ b/dbaas/account/tests/factory.py
@@ -22,5 +22,6 @@ class TeamFactory(factory.DjangoModelFactory):
 
     name = factory.Sequence(lambda n: 'team_{0}'.format(n))
     email = factory.Sequence(lambda n: 'team_{0}@email.test.com'.format(n))
+    contacts = factory.Sequence(lambda n: '{0} - contact'.format(n))
 
     role = factory.SubFactory(RoleFactory)

--- a/dbaas/account/tests/test_team.py
+++ b/dbaas/account/tests/test_team.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 from django.test import TestCase
-from django.db import IntegrityError
+from django.core.exceptions import ValidationError
+from account.models import Team
+from account.views import emergency_contacts
 from . import factory
-from ..models import Team
-from drivers import base
-
-import logging
-
-LOG = logging.getLogger(__name__)
 
 
 class TeamTest(TestCase):
@@ -17,14 +13,41 @@ class TeamTest(TestCase):
         self.new_team = factory.TeamFactory()
 
     def test_create_new_team(self):
-        """ 
-        Test new Team creation 
-        """
         self.assertTrue(self.new_team.pk)
 
     def test_cant_create_a_new_user(self):
-        self.team = Team()
-        self.team.name = "Team1"
-        self.team.role_id = factory.RoleFactory().pk
+        team = Team()
+        team.name = "Team1"
+        team.role_id = factory.RoleFactory().pk
+        self.assertFalse(team.save())
 
-        self.assertFalse(self.team.save())
+    def test_can_get_emergency_contacts_by_view(self):
+        contacts_found = emergency_contacts(team_id=self.new_team.pk)
+        self.assertEqual(self.new_team.emergency_contacts, contacts_found)
+
+    def test_cannot_get_emergency_contacts_by_view_wrong_id(self):
+        contacts_found = emergency_contacts(team_id=-1)
+        self.assertIsNone(contacts_found)
+
+    def test_cannot_get_emergency_contacts_by_view_invalid_id(self):
+        contacts_found = emergency_contacts(team_id="")
+        self.assertIsNone(contacts_found)
+
+    def test_can_get_emergency_contacts_by_property(self):
+        response = self.new_team.emergency_contacts
+        self.assertEqual(response, self.new_team.contacts)
+
+    def test_cannot_get_emergency_contacts_by_property(self):
+        team = factory.TeamFactory()
+        team.contacts = None
+        response = team.emergency_contacts
+        self.assertEqual(response, 'Not defined. Please, contact the team')
+
+    def test_clean_does_not_raise_validation_error(self):
+        team = factory.TeamFactory()
+        self.assertIsNone(team.clean())
+
+    def test_clean_raises_validation_error(self):
+        team = factory.TeamFactory()
+        team.contacts = None
+        self.assertRaises(ValidationError, team.clean)

--- a/dbaas/account/tests/test_urls.py
+++ b/dbaas/account/tests/test_urls.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+
+
+class UrlTest(TestCase):
+
+    def test_access_emergency_contacts_url(self):
+        response = self.client.get('/account/team_contacts/{}'.format(01234))
+        self.assertEqual(response.status_code, 200)
+
+    def test_cannot_access_emergency_contacts_url_invalid_parameter(self):
+        response = self.client.get('/account/team_contacts/abcde')
+        self.assertEqual(response.status_code, 301)

--- a/dbaas/account/urls.py
+++ b/dbaas/account/urls.py
@@ -2,11 +2,11 @@ from django.conf.urls import *
 from forms.change_password_form import ChangePasswordForm
 from dbaas import settings
 
-urlpatterns = patterns('account.views',
-                       url(r'^profile/(?P<user_id>\d+)/?$',
-                           "profile", name="account.profile"),
-
-                       )
+urlpatterns = patterns(
+    'account.views',
+    url(r'^profile/(?P<user_id>\d+)/?$', "profile", name="account.profile"),
+    url(r"^team_contacts/(?P<team_id>\d*)$", "team_contacts", name="contacts"),
+)
 
 if settings.LDAP_ENABLED:
     urlpatterns += patterns('',

--- a/dbaas/account/views.py
+++ b/dbaas/account/views.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 import logging
+import json
 from django.contrib.auth.models import User
-from django.contrib import messages
+from django.core.exceptions import ObjectDoesNotExist
 from django.template import RequestContext
 from django.http import HttpResponse
-from django.http import HttpResponseRedirect
-from django.conf import settings
 from django.shortcuts import render_to_response
-from django.template.loader import render_to_string
-from django.contrib.auth.decorators import login_required, user_passes_test
-from django.utils.datastructures import SortedDict
+from django.contrib.auth.decorators import login_required
 from account.models import Team
 from logical.models import Database
 
@@ -33,3 +30,19 @@ def profile(request, user_id=None):
         LOG.warning("Ops... %s" % e)
 
     return render_to_response("account/profile.html", locals(), context_instance=RequestContext(request))
+
+
+def emergency_contacts(team_id):
+    try:
+        team = Team.objects.get(id=team_id)
+    except (ObjectDoesNotExist, ValueError):
+        return
+    else:
+        return team.emergency_contacts
+
+
+def team_contacts(self, team_id):
+    response_json = json.dumps({
+        "contacts": emergency_contacts(team_id)
+    })
+    return HttpResponse(response_json, content_type="application/json")

--- a/dbaas/api/database.py
+++ b/dbaas/api/database.py
@@ -38,7 +38,7 @@ class DatabaseSerializer(serializers.HyperlinkedModelSerializer):
         fields = (
             'url', 'id', 'name', 'endpoint', 'plan', 'environment',
             'project', 'team', 'quarantine_dt', 'total_size_in_bytes',
-            'credentials', 'description', 'contacts', 'status',
+            'credentials', 'description', 'status',
             'used_size_in_bytes', 'subscribe_to_email_events',
             'created_at',
         )
@@ -109,8 +109,7 @@ class DatabaseAPI(viewsets.ModelViewSet):
                 environment=data['environment'], team=data['team'],
                 project=data['project'], description=data['description'],
                 subscribe_to_email_events=data['subscribe_to_email_events'],
-                contacts=data['contacts'], task_history=task_history,
-                user=request.user
+                task_history=task_history, user=request.user
             )
 
             headers = self.get_success_headers(data)

--- a/dbaas/api/tests/test_databaseapi.py
+++ b/dbaas/api/tests/test_databaseapi.py
@@ -57,7 +57,6 @@ class DatabaseAPITestCase(DbaaSAPITestCase, BasicTestsMixin):
         self.assertEquals(test_obj.team, call_args['team'])
         self.assertEquals(test_obj.project, call_args['project'])
         self.assertEquals(test_obj.description, call_args['description'])
-        self.assertEquals(test_obj.contacts, call_args['contacts'])
 
     def payload(self, database, **kwargs):
         data = {
@@ -67,7 +66,6 @@ class DatabaseAPITestCase(DbaaSAPITestCase, BasicTestsMixin):
             'team': reverse('team-detail', kwargs={'pk': database.team.pk}),
             'project': reverse('project-detail', kwargs={'pk': database.project.pk}),
             'description': database.description,
-            'contacts': database.contacts
         }
         return data
 

--- a/dbaas/logical/admin/database.py
+++ b/dbaas/logical/admin/database.py
@@ -83,8 +83,8 @@ class DatabaseAdmin(admin.DjangoServicesAdmin):
     fieldsets_add = (
         (None, {
             'fields': (
-                'name', 'description', 'contacts', 'project', 'engine',
-                'environment', 'team', 'subscribe_to_email_events', 'plan',
+                'name', 'description', 'project', 'engine',
+                'environment', 'team', 'team_contact', 'subscribe_to_email_events', 'plan',
                 'is_in_quarantine',
             )
         }
@@ -94,12 +94,13 @@ class DatabaseAdmin(admin.DjangoServicesAdmin):
     fieldsets_change_basic = (
         (None, {
             'fields': [
-                'name', 'description', 'contacts', 'project', 'team',
+                'name', 'description', 'project', 'team', 'team_contact',
                 'subscribe_to_email_events', 'disk_auto_resize',
             ]
-        }
-        ),
+        }),
     )
+
+    readonly_fields = ('team_contact',)
 
     fieldsets_change_advanced = (
         (None, {
@@ -419,7 +420,6 @@ class DatabaseAdmin(admin.DjangoServicesAdmin):
                     project=form.cleaned_data['project'],
                     description=form.cleaned_data['description'],
                     subscribe_to_email_events=form.cleaned_data['subscribe_to_email_events'],
-                    contacts=form.cleaned_data['contacts'],
                     task_history=task_history,
                     user=request.user
                 )

--- a/dbaas/logical/forms/database.py
+++ b/dbaas/logical/forms/database.py
@@ -13,7 +13,6 @@ from logical.forms.fields import AdvancedModelChoiceField
 from logical.models import Database
 from logical.validators import database_name_evironment_constraint
 
-
 LOG = logging.getLogger(__name__)
 
 
@@ -104,7 +103,6 @@ class CloneDatabaseForm(forms.Form):
 
         return cleaned_data
 
-
 class DatabaseForm(models.ModelForm):
     plan = AdvancedModelChoiceField(queryset=Plan.objects.filter(is_active='True'),
                                     required=False, widget=forms.RadioSelect,
@@ -115,7 +113,7 @@ class DatabaseForm(models.ModelForm):
     class Meta:
         model = Database
         fields = (
-            'name', 'description', 'contacts', 'subscribe_to_email_events',
+            'name', 'description', 'subscribe_to_email_events',
             'project', 'team', 'is_in_quarantine',
         )
 
@@ -176,12 +174,6 @@ class DatabaseForm(models.ModelForm):
                 self._errors["description"] = self.error_class(
                     [_("Description: This field is required.")])
 
-    def _validate_contacts(self, cleaned_data):
-        if 'contacts' in cleaned_data:
-            if not cleaned_data.get('contacts', None):
-                self._errors["contacts"] = self.error_class(
-                    [_("Contacts: This field is required.")])
-
     def _validate_project(self, cleaned_data):
         if 'project' in cleaned_data:
             if not cleaned_data.get('project', None):
@@ -228,7 +220,6 @@ class DatabaseForm(models.ModelForm):
         if self.instance and self.instance.id:
             self._validate_project(cleaned_data)
             self._validate_description(cleaned_data)
-            self._validate_contacts(cleaned_data)
             self._validate_team(cleaned_data)
             return cleaned_data
 
@@ -244,7 +235,6 @@ class DatabaseForm(models.ModelForm):
         self._validate_name(cleaned_data)
         self._validate_project(cleaned_data)
         self._validate_description(cleaned_data)
-        self._validate_contacts(cleaned_data)
         self._validate_team(cleaned_data)
 
         if 'environment' in cleaned_data:

--- a/dbaas/logical/models.py
+++ b/dbaas/logical/models.py
@@ -118,6 +118,11 @@ class Database(BaseModel):
         )
     )
 
+    def team_contact(self):
+        if self.team:
+            return self.team.emergency_contacts
+    team_contact.short_description = 'Emergency contacts'
+
     objects = models.Manager()
     alive = DatabaseAliveManager()
     quarantine_time = Configuration.get_by_name_as_int(

--- a/dbaas/logical/static/js/database_admin.js
+++ b/dbaas/logical/static/js/database_admin.js
@@ -370,6 +370,23 @@
             database.update_components();
         });
 
+        $("#id_team").on("change", function() {
+            var team = document.getElementById('id_team').value;
+            $.ajax({
+                "type": "GET",
+                "url": "/account/team_contacts/" + team
+            }).done(function (response) {
+                contacts = "";
+                if(response.contacts != null)
+                    contacts = response.contacts;
+
+                document.getElementsByClassName("field-team_contact")[0].innerHTML = "" +
+                    '<div class="control-label"><label>Emergency contacts:</label></div>' +
+                    '<div class="controls">' +
+                    "<p>" + contacts + "</p></div>";
+            });
+        });
+
         $(".plan").on("click", function() {
             $("input", ".plan").removeAttr("checked");
             $("input", $(this)).attr("checked", "checked");
@@ -384,7 +401,7 @@
                 $("#database_form").submit();
             }else{
                 $(".btn-plan").attr('disabled', false);
-                return false
+                return false;
             }
 
         });

--- a/dbaas/logical/tests/factory.py
+++ b/dbaas/logical/tests/factory.py
@@ -23,7 +23,6 @@ class DatabaseFactory(factory.DjangoModelFactory):
     project = factory.SubFactory(ProjectFactory)
     team = factory.SubFactory(TeamFactory)
     description = factory.Sequence(lambda n: 'desc{0}'.format(n))
-    contacts = factory.Sequence(lambda n: 'Jhon{0} Doe'.format(n))
 
     @factory.lazy_attribute
     def environment(self):

--- a/dbaas/logical/tests/test_admin_database.py
+++ b/dbaas/logical/tests/test_admin_database.py
@@ -34,7 +34,6 @@ class AdminCreateDatabaseTestCase(TestCase):
         self.team.users.add(self.user)
         self.client.login(username=self.USERNAME, password=self.PASSWORD)
         self.description = "My database"
-        self.contacts = "Jhon Doe - 99999999"
 
     def tearDown(self):
         self.engine = None
@@ -49,7 +48,6 @@ class AdminCreateDatabaseTestCase(TestCase):
             "environment": self.environment.pk,
             "engine": self.databaseinfra.engine.pk,
             "description": self.description,
-            "contacts": self.contacts
         }
         response = self.client.post("/admin/logical/database/add/", params)
         self.assertContains(
@@ -69,22 +67,6 @@ class AdminCreateDatabaseTestCase(TestCase):
         self.assertContains(
             response, "Description: This field is required.", status_code=200)
 
-    def test_user_tries_to_create_database_without_contacts(self):
-        database_name = "test_new_database_without_team"
-        params = {
-            "name": database_name,
-            "project": self.project.pk,
-            "plan": self.plan.pk,
-            "environment": self.environment.pk,
-            "engine": self.databaseinfra.engine.pk,
-            "description": self.description,
-            "team": self.team.pk
-        }
-        response = self.client.post("/admin/logical/database/add/", params)
-        self.assertContains(
-            response, "This field is required.", status_code=200
-        )
-
     def test_try_create_a_new_database_but_database_already_exists(self):
         database_name = "test_new_database"
         self.database = factory.DatabaseFactory(
@@ -97,7 +79,6 @@ class AdminCreateDatabaseTestCase(TestCase):
             "engine": self.databaseinfra.engine.pk,
             "team": self.team.pk,
             "description": self.description,
-            "contacts": self.contacts
         }
         response = self.client.post("/admin/logical/database/add/", params)
         self.assertContains(
@@ -123,7 +104,6 @@ class AdminCreateDatabaseTestCase(TestCase):
             "engine": self.databaseinfra.engine.pk,
             "team": self.team.pk,
             "description": self.description,
-            "contacts": self.contacts
         }
         response = self.client.post("/admin/logical/database/add/", params)
         self.assertEqual(response.status_code, 302, response.content)

--- a/dbaas/notification/tasks.py
+++ b/dbaas/notification/tasks.py
@@ -39,7 +39,7 @@ def rollback_database(dest_database):
 
 @app.task(bind=True)
 def create_database(
-    self, name, plan, environment, team, project, description, contacts,
+    self, name, plan, environment, team, project, description,
     subscribe_to_email_events=True, task_history=None, user=None
 ):
     AuditRequest.new_request("create_database", user, "localhost")
@@ -63,8 +63,7 @@ def create_database(
         result = make_infra(
             plan=plan, environment=environment, name=name, team=team,
             project=project, description=description,
-            subscribe_to_email_events=subscribe_to_email_events, task=task_history,
-            contacts=contacts
+            subscribe_to_email_events=subscribe_to_email_events, task=task_history
         )
 
         if result['created'] is False:
@@ -151,7 +150,7 @@ def clone_database(self, origin_database, clone_name, plan, environment, task_hi
             plan=plan, environment=environment, name=clone_name,
             team=origin_database.team, project=origin_database.project,
             description=origin_database.description, task=task_history,
-            clone=origin_database, contacts=origin_database.contacts,
+            clone=origin_database,
             subscribe_to_email_events=origin_database.subscribe_to_email_events
         )
 

--- a/dbaas/tsuru/views.py
+++ b/dbaas/tsuru/views.py
@@ -436,7 +436,6 @@ class ServiceAdd(APIView):
         create_database.delay(
             name=name, plan=dbaas_plan, environment=dbaas_environment,
             team=dbaas_team, project=None, description=description,
-            contacts=None,
             task_history=task_history, user=dbaas_user
         )
 

--- a/dbaas/util/providers.py
+++ b/dbaas/util/providers.py
@@ -14,7 +14,7 @@ LOG = logging.getLogger(__name__)
 
 
 def make_infra(
-    plan, environment, name, team, project, description, contacts,
+    plan, environment, name, team, project, description,
     subscribe_to_email_events=True, task=None,
 ):
     if not plan.provider == plan.CLOUDSTACK:
@@ -28,7 +28,6 @@ def make_infra(
             database.description = description
             database.project = project
             database.subscribe_to_email_events = subscribe_to_email_events
-            database.contacts = contacts
             database.save()
 
             return build_dict(
@@ -43,7 +42,6 @@ def make_infra(
         ), qt=get_vm_qt(plan=plan, ), dbtype=str(plan.engine_type),
         team=team, project=project, description=description,
         subscribe_to_email_events=subscribe_to_email_events,
-        contacts=contacts,
     )
 
     start_workflow(workflow_dict=workflow_dict, task=task)
@@ -52,7 +50,7 @@ def make_infra(
 
 def clone_infra(
         plan, environment, name, team, project, description,
-        subscribe_to_email_events, contacts, task=None, clone=None
+        subscribe_to_email_events, task=None, clone=None
 ):
     if not plan.provider == plan.CLOUDSTACK:
         infra = DatabaseInfra.best_for(
@@ -67,12 +65,11 @@ def clone_infra(
 
             return build_dict(
                 databaseinfra=infra, database=database, created=True,
-                contacts=contacts,
                 subscribe_to_email_events=subscribe_to_email_events
             )
 
         return build_dict(
-            databaseinfra=None, created=False, contacts=contacts,
+            databaseinfra=None, created=False,
             subscribe_to_email_events=subscribe_to_email_events
         )
 
@@ -90,7 +87,6 @@ def clone_infra(
         description=description,
         clone=clone,
         subscribe_to_email_events=subscribe_to_email_events,
-        contacts=contacts
     )
 
     start_workflow(workflow_dict=workflow_dict, task=task)

--- a/dbaas/workflow/steps/util/deploy/build_database.py
+++ b/dbaas/workflow/steps/util/deploy/build_database.py
@@ -43,9 +43,6 @@ class BuildDatabase(BaseStep):
             LOG.info("Updating database subscribe_to_email_events")
             database.subscribe_to_email_events = workflow_dict['subscribe_to_email_events']
 
-            LOG.info("Updating database contacts")
-            database.contacts = workflow_dict['contacts']
-
             database.save()
             workflow_dict['database'] = database
 


### PR DESCRIPTION
- Did not delete field from database model (maintenance reasons), but it's not shown on forms anymore;
- Create contacts field on team model;
- Remove references to database contacts;
- Show emergency contacts read-only field on database forms that is changed dynamically with team's choice;
- Create test cases for new changes.