### PR TITLE
Fix vm resize button.

### DIFF
--- a/dbaas/logical/templates/logical/database/details/resizes_tab.html
+++ b/dbaas/logical/templates/logical/database/details/resizes_tab.html
@@ -127,7 +127,7 @@
     $("#id_disk_offering").change()
 
     $("#id_vm_offering").on("change", function() {
-      status_resize("vm_resize_btn", '{{ current_vm_offering.serviceofferingid }}', $(this).val())
+      status_resize("vm_resize_btn", '{{ current_vm_offering.id }}', $(this).val())
     });
     $("#id_vm_offering").change()
 


### PR DESCRIPTION
On resize tab on logical database. The button must be disabled when
the selected offer is the actual offer.