### PR TITLE
Fix format style of response of /reset_password/ endpoint

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -238,13 +238,13 @@ Generate a new password for your credential
 Response:
 
     {
-    "_links": {
-        "self": "http://localhost:8000/api/credential/1/"
-    }, 
-    "id": 1, 
-    "user": "u_test_database2", 
-    "database": "http://localhost:8000/api/database/1/", 
-    "password": "PReduz6QtA"
+        "_links": {
+            "self": "http://localhost:8000/api/credential/1/"
+        }, 
+        "id": 1, 
+        "user": "u_test_database2", 
+        "database": "http://localhost:8000/api/database/1/", 
+        "password": "PReduz6QtA"
     }
 
 ### DELETE /api/credential/*some_id*/


### PR DESCRIPTION
**Description of the change**: Corrects the format style of response of the /api/credential/some_id/reset_password/ endpoint in API.md file.
**Reason for the change**: The format style of response is not in the pattern of the others
**Link to original source**:
https://github.com/globocom/database-as-a-service/blob/master/doc/API.md