### PR TITLE
Bugfix - MongoDB stay locked after backup

### DIFF
--- a/dbaas/backup/tasks.py
+++ b/dbaas/backup/tasks.py
@@ -75,10 +75,14 @@ def lock_instance(driver, instance, client):
 
 
 def unlock_instance(driver, instance, client):
-    LOG.debug('Unlocking instance {}'.format(instance))
-    driver.unlock_database(client)
-    LOG.debug('Instance {} is unlocked'.format(instance))
-
+    try:
+        LOG.debug('Unlocking instance {}'.format(instance))
+        driver.unlock_database(client)
+        LOG.debug('Instance {} is unlocked'.format(instance))
+        return True
+    except Exception as e:
+        LOG.warning('Could not unlock {} - {}'.format(instance, e))
+        return False
 
 def make_instance_snapshot_backup(instance, error, group, provider_class=VolumeProviderBase):
     LOG.info("Make instance backup for {}".format(instance))
@@ -109,8 +113,7 @@ def make_instance_snapshot_backup(instance, error, group, provider_class=VolumeP
         set_backup_error(infra, snapshot, errormsg)
         return snapshot
     finally:
-        if locked:
-            unlock_instance(driver, instance, client)
+        unlock_instance(driver, instance, client)
 
     output = {}
     command = "du -sb /data/.snapshot/%s | awk '{print $1}'" % (

--- a/dbaas/drivers/mongodb.py
+++ b/dbaas/drivers/mongodb.py
@@ -159,7 +159,7 @@ class MongoDB(BaseDriver):
             # mongo uses timeout in mili seconds
             connection_timeout_in_miliseconds = Configuration.get_by_name_as_int(
                 'mongo_connect_timeout', default=MONGO_CONNECTION_DEFAULT_TIMEOUT) * 1000
-            
+
             server_selection_timeout_in_seconds = Configuration.get_by_name_as_int(
                 'mongo_server_selection_timeout', default=MONGO_SERVER_SELECTION_DEFAULT_TIMEOUT) * 1000
 
@@ -187,6 +187,9 @@ class MongoDB(BaseDriver):
         client.fsync(lock=True)
 
     def unlock_database(self, client):
+        """ This method unlocks a database instance for writing purposes.
+        MongoDB is going to throw an exception when trying to unlock an already
+        locked database. """
         client.unlock()
 
     @contextmanager


### PR DESCRIPTION
- Always unlocking database after backup.
- There's an exception for MongoDB drivers when trying to unlock an
  already locked database. In this case or any other exception, we're
  going to return false for the 'unlock_instance' method.
- Documentation: unlock_database.