### PR TITLE
Bugfix - Tsuru unbinding not working to old databases

### DIFF
--- a/dbaas/backup/tasks.py
+++ b/dbaas/backup/tasks.py
@@ -75,10 +75,14 @@ def lock_instance(driver, instance, client):
 
 
 def unlock_instance(driver, instance, client):
-    LOG.debug('Unlocking instance {}'.format(instance))
-    driver.unlock_database(client)
-    LOG.debug('Instance {} is unlocked'.format(instance))
-
+    try:
+        LOG.debug('Unlocking instance {}'.format(instance))
+        driver.unlock_database(client)
+        LOG.debug('Instance {} is unlocked'.format(instance))
+        return True
+    except Exception as e:
+        LOG.warning('Could not unlock {} - {}'.format(instance, e))
+        return False
 
 def make_instance_snapshot_backup(instance, error, group, provider_class=VolumeProviderBase):
     LOG.info("Make instance backup for {}".format(instance))
@@ -109,8 +113,7 @@ def make_instance_snapshot_backup(instance, error, group, provider_class=VolumeP
         set_backup_error(infra, snapshot, errormsg)
         return snapshot
     finally:
-        if locked:
-            unlock_instance(driver, instance, client)
+        unlock_instance(driver, instance, client)
 
     output = {}
     command = "du -sb /data/.snapshot/%s | awk '{print $1}'" % (

--- a/dbaas/dbaas/urls.py
+++ b/dbaas/dbaas/urls.py
@@ -16,7 +16,7 @@ urlpatterns = patterns(
     url(r'^$', RedirectView.as_view(url='/admin'), name='home'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^dashboard/', include('dashboard.urls')),
-    url(r'^([^/]+)/tsuru/', include('tsuru.urls')),
+    url(r'^([^/]+)/tsuru/', include('tsuru.urls', namespace='tsuru')),
     url(r'^logical/', include('logical.urls')),
     url(r'^account/', include('account.urls')),
     url(r'^system/', include('system.urls')),

--- a/dbaas/drivers/mongodb.py
+++ b/dbaas/drivers/mongodb.py
@@ -159,7 +159,7 @@ class MongoDB(BaseDriver):
             # mongo uses timeout in mili seconds
             connection_timeout_in_miliseconds = Configuration.get_by_name_as_int(
                 'mongo_connect_timeout', default=MONGO_CONNECTION_DEFAULT_TIMEOUT) * 1000
-            
+
             server_selection_timeout_in_seconds = Configuration.get_by_name_as_int(
                 'mongo_server_selection_timeout', default=MONGO_SERVER_SELECTION_DEFAULT_TIMEOUT) * 1000
 
@@ -187,6 +187,9 @@ class MongoDB(BaseDriver):
         client.fsync(lock=True)
 
     def unlock_database(self, client):
+        """ This method unlocks a database instance for writing purposes.
+        MongoDB is going to throw an exception when trying to unlock an already
+        locked database. """
         client.unlock()
 
     @contextmanager

--- a/dbaas/tsuru/tests/test_check_database_status.py
+++ b/dbaas/tsuru/tests/test_check_database_status.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+from mock import patch
+from unittest import TestCase
+from rest_framework import status
+from rest_framework.response import Response
+
+from maintenance.models import DatabaseCreate, DatabaseMaintenanceTask
+from logical.models import Database
+from tsuru.views import check_database_status
+from notification.tests.factory import TaskHistoryFactory
+
+
+@patch('tsuru.views.get_database')
+@patch('tsuru.views.last_database_create')
+class CheckDatabaseStatusTestCase(TestCase):
+
+    def setUp(self):
+        self.fake_database_create = DatabaseCreate()
+        self.fake_database_create.task = TaskHistoryFactory.build()
+        self.fake_database = Database()
+
+    def test_check_database_status_success(self, mock_database_create, mock_database):
+        self.fake_database_create.status = DatabaseMaintenanceTask.SUCCESS
+        mock_database_create.return_value = self.fake_database_create
+        mock_database.return_value = self.fake_database
+
+        response = check_database_status('test_database', 'dev')
+        self.assertIsInstance(response, Database)
+
+    def test_check_database_status_running(self, mock_database_create, mock_database):
+        self.fake_database_create.status = DatabaseMaintenanceTask.RUNNING
+        mock_database_create.return_value = self.fake_database_create
+        mock_database.return_value = self.fake_database
+
+        response = check_database_status('test_database', 'dev')
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, status.HTTP_412_PRECONDITION_FAILED)
+
+    def test_check_database_status_error(self, mock_database_create, mock_database):
+        self.fake_database_create.status = DatabaseMaintenanceTask.ERROR
+        mock_database_create.return_value = self.fake_database_create
+        mock_database.return_value = self.fake_database
+
+        response = check_database_status('test_database', 'dev')
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/dbaas/tsuru/tests/test_service_app_bind_delete.py
+++ b/dbaas/tsuru/tests/test_service_app_bind_delete.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from mock import patch
+from mock import Mock
+import json
+
+from django.test.client import Client
+from django.contrib.auth.models import User, Group
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.response import Response
+
+from account.models import AccountUser, Role, Team, Organization
+from logical.models import Database
+from workflow.steps.util.base import ACLFromHellClient
+
+
+@patch('workflow.steps.util.base.ACLFromHellClient.remove_acl')
+@patch('tsuru.views.check_database_status')
+class ServiceAppBindDeleteTestCase(TestCase):
+    """HTTP test cases for the tsuru unbind API. This class focuses on the
+    DELETE method.
+    """
+    USERNAME = "test-ui-database"
+    PASSWORD = "123456"
+
+    def setUp(self):
+        self.role = Role.objects.get_or_create(name="fake_role")[0]
+        self.organization = Organization.objects.get_or_create(name='fake_organization')[0]
+        self.team = Team.objects.get_or_create(
+            name="fake_team", role=self.role,
+            organization = self.organization)[0]
+        self.superuser = User.objects.create_superuser(
+            self.USERNAME, email="%s@admin.com" % self.USERNAME, password=self.PASSWORD)
+        self.team.users.add(self.superuser)
+        self.client.login(username=self.USERNAME, password=self.PASSWORD)
+
+    def tearDown(self):
+        self.client.logout()
+
+    def test_user_is_authenticated(self, mock_check_database_status, mock_acl_from_hell):
+        """It tests user is authenticated."""
+        mock_check_database_status.return_value = Response({}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = self.client.delete(url, json.dumps({'app-name': 'test-app'}), content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def test_user_login_invalid(self, mock_check_database_status, mock_acl_from_hell):
+        """It tests user is not authenticated."""
+        client = Client()
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = client.delete(url, {'app-name': 'test-app'})
+
+        self.assertEquals(response.status_code, 401)
+
+    def test_delete_204(self, mock_check_database_status, mock_acl_from_hell):
+        """ It tests if database.databaseinfra.engine.name is equal mysql. It
+        must return the env_vars to a mysql.
+        """
+        mock_database = Mock(spec=Database)
+        print('instance:', isinstance(mock_database, Database))
+        # attrs = {'environment': 'dev'}
+        # mock_database.configure_mock(**attrs)
+        mock_check_database_status.return_value = Mock(spec=Database)
+        mock_acl_from_hell.return_value = None
+
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = self.client.delete(url, json.dumps({'app-name': 'test-app'}), content_type='application/json')
+
+        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/dbaas/tsuru/tests/test_service_app_bind_post.py
+++ b/dbaas/tsuru/tests/test_service_app_bind_post.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+from mock import patch
+from mock import Mock
+
+from django.test.client import Client
+from django.contrib.auth.models import User, Group
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.response import Response
+
+from account.models import AccountUser, Role, Team, Organization
+from logical.models import Database
+
+
+@patch('tsuru.views.ServiceAppBind.add_acl_for_hosts')
+@patch('tsuru.views.check_database_status')
+class ServiceAppBindPostTestCase(TestCase):
+    """HTTP test cases for the tsuru bind API. This class focuses on the POST
+    method.
+    """
+    USERNAME = "test-ui-database"
+    PASSWORD = "123456"
+
+    def setUp(self):
+        self.role = Role.objects.get_or_create(name="fake_role")[0]
+        self.organization = Organization.objects.get_or_create(name='fake_organization')[0]
+        self.team = Team.objects.get_or_create(
+            name="fake_team", role=self.role,
+            organization = self.organization)[0]
+        self.superuser = User.objects.create_superuser(
+            self.USERNAME, email="%s@admin.com" % self.USERNAME, password=self.PASSWORD)
+        self.team.users.add(self.superuser)
+        self.client.login(username=self.USERNAME, password=self.PASSWORD)
+
+    def tearDown(self):
+        self.client.logout()
+
+    def test_user_is_authenticated(self, mock_check_database_status, mock_add_acl_for_hosts):
+        """It tests user is authenticated."""
+        mock_check_database_status.return_value = Response({}, status=status.HTTP_200_OK)
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = self.client.post(url, {'app-name': 'test-app'})
+
+        self.assertEquals(response.status_code, 200)
+
+    def test_user_login_invalid(self, mock_check_database_status, mock_add_acl_for_hosts):
+        """It tests user is not authenticated."""
+        client = Client()
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = client.post(url, {'app-name': 'test-app'})
+
+        self.assertEquals(response.status_code, 401)
+
+    def test_redis_engine_without_sentinel(self, mock_check_database_status, mock_add_acl_for_hosts):
+        """ It tests if database.databaseinfra.engine.name is equal redis. It
+        must return the env_vars to a redis without sentinel, wheater it is single
+        or cluster configuration.
+        """
+        mock_add_acl_for_hosts.return_value = None
+        mock_database = Mock(spec=Database)
+        attrs = {'infra.get_driver.return_value.get_dns_port.return_value': ['test_redis_host', 8000],
+                 'databaseinfra.engine.name': 'redis',
+                 'databaseinfra.password': 'test_password',
+                 'get_endpoint_dns.return_value': 'test.com:<password>',
+                 'infra.get_driver.return_value.topology_name.return_value': ['redis_single']}
+        mock_database.configure_mock(**attrs)
+        mock_check_database_status.return_value = mock_database
+
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = self.client.post(url, {'app-name': 'test-app'})
+
+        expected_data = {'DBAAS_REDIS_PASSWORD': 'test_password',
+                         'DBAAS_REDIS_PORT': '8000',
+                         'DBAAS_REDIS_HOST': 'test_redis_host',
+                         'DBAAS_REDIS_ENDPOINT': 'test.com:test_password'}
+
+        self.assertEquals(response.data, expected_data)
+        self.assertEquals(response.status_code, 201)
+
+    def test_redis_engine_with_sentinel(self, mock_check_database_status, mock_add_acl_for_hosts):
+        """ It tests if database.databaseinfra.engine.name is equal redis. It
+        must return the env_vars to a redis sentinel.
+        """
+        mock_add_acl_for_hosts.return_value = None
+        mock_database = Mock(spec=Database)
+        attrs = {
+            'infra.get_driver.return_value.get_dns_port.return_value': ['test_redis_host', 8000],
+             'databaseinfra.engine.name': 'redis',
+             'databaseinfra.password': 'test_password',
+             'get_endpoint_dns.return_value': 'test.com:<password>',
+             'infra.get_driver.return_value.topology_name.return_value': ['redis_sentinel'],
+             'get_endpoint_dns_simple.return_value': 'cluster',
+             'databaseinfra.name': 'test_infra'
+        }
+        mock_database.configure_mock(**attrs)
+        mock_check_database_status.return_value = mock_database
+
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = self.client.post(url, {'app-name': 'test-app'})
+
+        expected_data = {
+            'DBAAS_SENTINEL_PASSWORD': 'test_password',
+            'DBAAS_SENTINEL_ENDPOINT': 'test.com:test_password',
+            'DBAAS_SENTINEL_ENDPOINT_SIMPLE': 'cluster',
+            'DBAAS_SENTINEL_SERVICE_NAME': 'test_infra',
+            'DBAAS_SENTINEL_HOSTS': 'test_redis_host',
+            'DBAAS_SENTINEL_PORT': '8000'
+        }
+
+        self.assertEquals(response.data, expected_data)
+        self.assertEquals(response.status_code, 201)
+
+    def test_mysql_engine(self, mock_check_database_status, mock_add_acl_for_hosts):
+        """ It tests if database.databaseinfra.engine.name is equal mysql. It
+        must return the env_vars to a mysql.
+        """
+        mock_add_acl_for_hosts.return_value = None
+        mock_database = Mock(spec=Database)
+        attrs = {
+            'infra.get_driver.return_value.get_dns_port.return_value': ['test_mysql_hosts', 8000],
+            'databaseinfra.engine.name': 'mysql',
+            'credentials.all.return_value': [Mock(user='test_mysql', password='test_password')],
+            'get_endpoint_dns.return_value': 'mysql:test.com:<user>:<password>'
+        }
+        mock_database.configure_mock(**attrs)
+        mock_check_database_status.return_value = mock_database
+
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = self.client.post(url, {'app-name': 'test-app'})
+
+        expected_data = {
+            "DBAAS_MYSQL_USER": 'test_mysql',
+            "DBAAS_MYSQL_PASSWORD": 'test_password',
+            "DBAAS_MYSQL_ENDPOINT": 'mysql:test.com:test_mysql:test_password',
+            "DBAAS_MYSQL_HOSTS": 'test_mysql_hosts',
+            "DBAAS_MYSQL_PORT": '8000'
+        }
+
+        self.assertEquals(response.data, expected_data)
+        self.assertEquals(response.status_code, 201)
+
+    def test_mongodb_engine(self, mock_check_database_status, mock_add_acl_for_hosts):
+        """ It tests if database.databaseinfra.engine.name is equal mongodb. It
+        must return the env_vars to a mongodb.
+        """
+        mock_add_acl_for_hosts.return_value = None
+        mock_database = Mock(spec=Database)
+        attrs = {
+            'infra.get_driver.return_value.get_dns_port.return_value': ['test_mongodb_hosts', 8000],
+            'databaseinfra.engine.name': 'mongodb',
+            'credentials.all.return_value': [Mock(user='test_mongodb', password='test_password')],
+            'get_endpoint_dns.return_value': 'mongodb:test.com:<user>:<password>'
+        }
+        mock_database.configure_mock(**attrs)
+        mock_check_database_status.return_value = mock_database
+
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = self.client.post(url, {'app-name': 'test-app'})
+
+        expected_data = {
+            "DBAAS_MONGODB_USER": 'test_mongodb',
+            "DBAAS_MONGODB_PASSWORD": 'test_password',
+            "DBAAS_MONGODB_ENDPOINT": 'mongodb:test.com:test_mongodb:test_password',
+            "DBAAS_MONGODB_HOSTS": 'test_mongodb_hosts',
+            "DBAAS_MONGODB_PORT": '8000'
+        }
+
+        self.assertEquals(response.data, expected_data)
+        self.assertEquals(response.status_code, 201)
+
+    def test_database_empty_credentials(self, mock_check_database_status, mock_add_acl_for_hosts):
+        """ It tests if database.databaseinfra.engine.name is equal mysql. It
+        must return the env_vars to a mysql.
+        """
+        mock_add_acl_for_hosts.return_value = None
+        mock_database = Mock(spec=Database)
+        attrs = {
+            'infra.get_driver.return_value.get_dns_port.return_value': ['test_mysql_hosts', 8000],
+            'databaseinfra.engine.name': 'mysql',
+            'credentials.all.return_value': [],
+            'get_endpoint_dns.return_value': 'mysql:test.com:<user>:<password>'
+        }
+        mock_database.configure_mock(**attrs)
+        mock_check_database_status.return_value = mock_database
+
+        url = reverse('tsuru:service-app-bind', args=('dev','test_database'))
+        response = self.client.post(url, {'app-name': 'test-app'})
+
+        self.assertEquals(response.status_code, 500)

--- a/dbaas/tsuru/urls.py
+++ b/dbaas/tsuru/urls.py
@@ -15,5 +15,5 @@ urlpatterns = patterns('tsuru.views',
                        url(r'^resources/(?P<database_name>\w+)/bind$',
                            ServiceUnitBind.as_view()),
                        url(r'^resources/(?P<database_name>\w+)/bind-app$',
-                           ServiceAppBind.as_view()),
+                           ServiceAppBind.as_view(), name='service-app-bind'),
                        )


### PR DESCRIPTION
- URLs
  - Namespace added to URLs files, that way endpoint is now accessible through reverse
- Views
  - Some necessary imports added
  - Inconsistency fix: ServiceAppBind.delete would return 200 instead of 204
  - check_database_status function fixed to use last_database_create(new) to find the most recent DatabaseCreate task
  - Documentation written for HTTP methods and functions
- Unit Tests
  - check_database_status test cases
  - ServiceAppBind.post test cases
  - ServiceAppBind.delete test cases