### PR TITLE
Add LICENSE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,7 @@ Documentation
 
 [Troubleshooting](./doc/troubleshooting.md)
 -------------------------------------------
+
+## License
+
+This project is licensed under the BSD 3-Clause "New" or "Revised" License - read [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
The README file for this repository does not contain the reference for license information.