### PR TITLE
Handle with generic mysql error

### DIFF
--- a/dbaas/drivers/base.py
+++ b/dbaas/drivers/base.py
@@ -98,6 +98,12 @@ class BaseDriver(object):
             func(*func_args, **func_kwargs)
         except ConnectionError:
             pass
+        except Exception as e:
+            error = e.message
+            if len(error) >= 2 and error[0] == 2002 and "Can't connect to " in error[1]:
+                return
+            raise e
+
 
     def try_remove_database(self, database):
         self._pass_if_connection_error(self.remove_database, database)


### PR DESCRIPTION
When I try to remove a dead mysql database I gotta the follow error:
```
File "/home/otherpirate/source/database-as-a-service/dbaas/logical/models.py", line 314, in delete
instance.try_remove_user(credential)
File "/home/otherpirate/source/database-as-a-service/dbaas/drivers/base.py", line 112, in try_remove_user
self._pass_if_connection_error(self.remove_user, credential)
File "/home/otherpirate/source/database-as-a-service/dbaas/drivers/base.py", line 105, in _pass_if_connection_error
raise e
GenericDriverError: GenericDriverError: (2002, "Can't connect to MySQL server on '<HOST_ADDRESS_HERE>' (115)")
```

The error happens on step: `Step 13 of 106 - Rollback Creating database`

This PR handle with this `GenericDriverError` and check the code of error